### PR TITLE
Fix symbol bit width calculation in case of exactly 2^n unique symbols

### DIFF
--- a/src/encode.h
+++ b/src/encode.h
@@ -235,7 +235,7 @@ std::vector<uint32_t> get_unique_symbols(const std::vector<BaseRLELine*>& rle_li
 }
 
 uint8_t estimate_symbol_bit_width(const std::vector<uint32_t>& unique_symbols) {
-    return get_bit_width(unique_symbols.size());
+    return get_bit_width(unique_symbols.size() - 1);
 }
 
 

--- a/tests/test_fastmask.py
+++ b/tests/test_fastmask.py
@@ -158,3 +158,19 @@ class TestInfo(unittest.TestCase):
 
             with self.assertRaises(ValueError):
                 pf.info(f.name)
+
+
+class TestSymbolBitWidth(unittest.TestCase):
+    def test_info_for_binary_image_returns_1bits_symbol_bit_width(self):
+        mask = np.array([[0, 1], [1, 0]], dtype=np.uint8)
+        with TempFile() as f:
+            pf.write(f, mask)
+            info = pf.info(f)
+            self.assertEqual(info['symbol_bit_width'], 1)
+
+    def test_info_for_256color_image_returns_8bits_symbol_bit_width(self):
+        mask = np.arange(256, dtype=np.uint8).reshape(16, 16)
+        with TempFile() as f:
+            pf.write(f, mask)
+            info = pf.info(f)
+            self.assertEqual(info['symbol_bit_width'], 8)


### PR DESCRIPTION
Previously encoder used 1 extra bit for masks with 2, 4, 8, 16 ... unique values.